### PR TITLE
fix: limit joined_at to timestamp in seconds or throw

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,12 +44,6 @@ jobs:
         uses: microsoft/setup-msbuild@v1.3.1
         if: runner.os == 'Windows'
 
-      - name: Setup node for windows
-        if: runner.os == 'Windows'
-        shell: bash
-        run: |
-          yarn global add node-gyp@latest
-
       # - name: sed it
       #   if: runner.os == 'Windows'
       #   shell: bash

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "main": "index.js",
   "name": "libsession_util_nodejs",
   "description": "Wrappers for the Session Util Library",
-  "version": "0.4.7",
+  "version": "0.4.8",
   "license": "GPL-3.0",
   "author": {
     "name": "Oxen Project",

--- a/src/user_groups_config.cpp
+++ b/src/user_groups_config.cpp
@@ -314,8 +314,8 @@ Napi::Value UserGroupsWrapper::setGroup(const Napi::CallbackInfo& info) {
                     obj.Get("joinedAtSeconds"), "UserGroupsWrapper::setGroup joinedAtSeconds")) {
             group_info.joined_at = *joinedAtSeconds;
         }
-        // 1st Jan 2100. Probably an invalid timestamp.
-        if (group_info.joined_at > 4099680000) {
+        // Probably an invalid timestamp.
+        if (group_info.joined_at > 9000000000) {
             throw std::invalid_argument{"group.joined_at is too far in the future"};
         }
 

--- a/src/user_groups_config.cpp
+++ b/src/user_groups_config.cpp
@@ -314,6 +314,10 @@ Napi::Value UserGroupsWrapper::setGroup(const Napi::CallbackInfo& info) {
                     obj.Get("joinedAtSeconds"), "UserGroupsWrapper::setGroup joinedAtSeconds")) {
             group_info.joined_at = *joinedAtSeconds;
         }
+        // 1st Jan 2100. Probably an invalid timestamp.
+        if (group_info.joined_at > 4099680000) {
+            throw std::invalid_argument{"group.joined_at is too far in the future"};
+        }
 
         if (auto invited = maybeNonemptyBoolean(
                     obj.Get("invitePending"), "UserGroupsWrapper::setGroup invitePending")) {


### PR DESCRIPTION
For the values already stored in libsession, we are making a on-band fix at <https://github.com/session-foundation/libsession-util/pull/13>
Still, I think it makes sense to have an exception thrown for those in the nodejs wrapper.