### PR TITLE
 Release v0.4.30

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,16 +44,15 @@ jobs:
         uses: microsoft/setup-msbuild@v1.3.1
         if: runner.os == 'Windows'
 
-        # Note: we will be able to get rid of this once the whole tree of submodules has the latest fetch of oxen-logging
+        # Note: we will be able to get rid of this once the whole tree of submodules has the latest version of oxen-logging
         # We'd need oxen-libquic to be updated to have the commit `bc7167f90e71643b43c2ea9cf7d1fefa5045f8d4`, but we don't want to
         # update libquic that late.
         # We will soon, though :tm:
-      - name: sed it
+      - name: Apply patches
         if: runner.os == 'Windows'
         shell: bash
         run: |
-          yarn dirty_sed
-          cat libsession-util/external/oxen-libquic/external/oxen-logging/CMakeLists.txt
+          yarn naughty-patch
 
       - name: generate fake src/version.h so we can try to build
         shell: bash

--- a/.gitignore
+++ b/.gitignore
@@ -12,5 +12,6 @@
 .yarn/
 *.cjs
 *.mjs
+.venv
 
 /src/version.h

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ git clone --recursive git@github.com:session-foundation/libsession-util-nodejs.g
 ```
 
 Always do your changes in `[FOLDER_NOT_IN_SESSION_DESKTOP]/libsession-util-nodejs`, never in the one under session-desktop's `node_modules` as you might override your local changes.
-Then, you can quickly compile a non-electron build by first running `yarn update_version` and then `yarn install` from that folder. You should only have to run `yarn update_version` manually once when you first setup the project. This is a quick incremental build which can check for C++ compilation errors.
+Then, you can quickly compile a non-electron build by first running `yarn naughty-patch && yarn update_version` and then `yarn install` from that folder. You should only have to run `yarn naughty-patch && yarn update_version` manually once when you first setup the project. This is a quick incremental build which can check for C++ compilation errors.
 Once your changes are ready to be tested in the `session-desktop` you can compile an electron build using this command:
 
 ```

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ git clone --recursive git@github.com:session-foundation/libsession-util-nodejs.g
 ```
 
 Always do your changes in `[FOLDER_NOT_IN_SESSION_DESKTOP]/libsession-util-nodejs`, never in the one under session-desktop's `node_modules` as you might override your local changes.
-Then, you can quickly compile a non-electron build by running `yarn cmake-js` from that folder. This is a quick incremental build which can check for C++ compilation errors.
+Then, you can quickly compile a non-electron build by first running `yarn update_version` and then `yarn install` from that folder. You should only have to run `yarn update_version` manually once when you first setup the project. This is a quick incremental build which can check for C++ compilation errors.
 Once your changes are ready to be tested in the `session-desktop` you can compile an electron build using this command:
 
 ```

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "update_version": "sh update_version.sh",
     "clean": "rimraf .cache build",
     "install": "cmake-js compile --runtime=electron --runtime-version=34.2.0 --CDSUBMODULE_CHECK=OFF --CDLOCAL_MIRROR=https://oxen.rocks/deps --CDENABLE_ONIONREQ=OFF --CDWITH_TESTS=OFF",
-    "naughty-patch": "git apply patches/*.patch",
+    "naughty-patch": "git apply patches/oxen-libquic.patch",
     "prepare_release": "sh prepare_release.sh"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "update_version": "sh update_version.sh",
     "clean": "rimraf .cache build",
     "install": "cmake-js compile --runtime=electron --runtime-version=34.2.0 --CDSUBMODULE_CHECK=OFF --CDLOCAL_MIRROR=https://oxen.rocks/deps --CDENABLE_ONIONREQ=OFF --CDWITH_TESTS=OFF",
-    "prepare_release": "sh prepare_release.sh",
-    "dirty_sed": "sed -i \"s/target_compile_options(oxen-logging-warnings INTERFACE/#target_compile_options(oxen-logging-warnings INTERFACE/\" libsession-util/external/oxen-libquic/external/oxen-logging/CMakeLists.txt"
+    "naughty-patch": "git apply patches/*.patch",
+    "prepare_release": "sh prepare_release.sh"
   },
   "devDependencies": {
     "clang-format": "^1.8.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "main": "index.js",
   "name": "libsession_util_nodejs",
   "description": "Wrappers for the Session Util Library",
-  "version": "0.4.28",
+  "version": "0.4.30",
   "license": "GPL-3.0",
   "author": {
     "name": "Oxen Project",

--- a/patches/oxen-libquic.patch
+++ b/patches/oxen-libquic.patch
@@ -1,0 +1,16 @@
+Submodule libsession-util contains modified content
+Submodule external/oxen-libquic contains modified content
+Submodule external/oxen-logging contains modified content
+diff --git a/libsession-util/external/oxen-libquic/external/oxen-logging/CMakeLists.txt b/libsession-util/external/oxen-libquic/external/oxen-logging/CMakeLists.txt
+index c8d0960..3b2d573 100644
+--- a/libsession-util/external/oxen-libquic/external/oxen-logging/CMakeLists.txt
++++ b/libsession-util/external/oxen-libquic/external/oxen-logging/CMakeLists.txt
+@@ -91,7 +91,7 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL GNU AND CMAKE_CXX_COMPILER_VERSION VERSION_GRE
+ endif()
+ 
+ add_library(oxen-logging-warnings INTERFACE)
+-target_compile_options(oxen-logging-warnings INTERFACE "$<$<OR:$<COMPILE_LANGUAGE:CXX>,$<COMPILE_LANGUAGE:C>>:${warning_flags}>")
++#target_compile_options(oxen-logging-warnings INTERFACE "$<$<OR:$<COMPILE_LANGUAGE:CXX>,$<COMPILE_LANGUAGE:C>>:${warning_flags}>")
+ target_link_libraries(oxen-logging INTERFACE oxen-logging-warnings)
+ 
+ set(oxen_logging_source_roots "" CACHE INTERNAL "")

--- a/prepare_release.sh
+++ b/prepare_release.sh
@@ -10,8 +10,8 @@ read_char() {
 
 
 rm -f ./libsession_util_nodejs*.tar.gz
-virtualenv venv
-. venv/bin/activate
+python -m venv .venv
+. .venv/bin/activate
 pip install git-archive-all
 PACKAGE_VERSION=$(node -p "require('./package.json').version")
 yarn update_version

--- a/prepare_release.sh
+++ b/prepare_release.sh
@@ -14,7 +14,7 @@ python -m venv .venv
 . .venv/bin/activate
 pip install git-archive-all
 # see .github/workflows/test.yml for more info
-yarn naughty-patch
+yarn naughty-patch || true
 PACKAGE_VERSION=$(node -p "require('./package.json').version")
 yarn update_version
 echo "PACKAGE_VERSION: $PACKAGE_VERSION"

--- a/prepare_release.sh
+++ b/prepare_release.sh
@@ -13,6 +13,8 @@ rm -f ./libsession_util_nodejs*.tar.gz
 python -m venv .venv
 . .venv/bin/activate
 pip install git-archive-all
+# see .github/workflows/test.yml for more info
+yarn naughty-patch
 PACKAGE_VERSION=$(node -p "require('./package.json').version")
 yarn update_version
 echo "PACKAGE_VERSION: $PACKAGE_VERSION"
@@ -25,8 +27,6 @@ esac
 
 
 echo "Continuing..."
-# see test.yml for explanation of this sed command
-yarn dirty_sed
 
 echo "Building tar archive of source..."
 python3 build_release_archive.py libsession_util_nodejs-v$PACKAGE_VERSION.tar.gz --include src/version.h


### PR DESCRIPTION
- Replaced the `dirty_sed` command with `naughty-patch` which uses git diff patches to resolve oxen-logging issues when building on windows.
- Updated the README instructions for compiling a non-electron build to include running `yarn naughty-patch` and `yarn update_version` before `yarn install` as they are prerequisites.
- Changed the virtual environment creation command from `virtualenv` to `python -m venv`. We don't enforce the python version at this time so we don't need `virtualenv` and can rely on python's native module.
- Updated the `libsession-util` submodule commit to the latest version to fix build issues with cmake.