### PR TITLE
feat: allow opting into a different runtime via env vars

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "clean": "rimraf .cache build",
     "lint:cpp": "cppcheck --std=c++20 -j8  src",
     "lint": "find src include -name '*.cpp' -o -name '*.hpp' | xargs clang-format-19 -i",
-    "install": "cmake-js build --runtime=electron --runtime-version=40.0.0 --CDSUBMODULE_CHECK=OFF --CDLOCAL_MIRROR=https://oxen.rocks/deps --CDENABLE_NETWORKING=OFF --CDWITH_TESTS=OFF",
+    "install": "node scripts/install.js",
     "prepare_release": "sh prepare_release.sh",
     "dedup": "pnpm dedupe --check"
   },

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+const { spawnSync } = require('child_process')
+
+const runtime = process.env.LIBSESSION_RUNTIME || 'electron'
+const runtimeVersion = process.env.LIBSESSION_RUNTIME_VERSION || '40.0.0'
+
+const result = spawnSync(
+  'cmake-js',
+  [
+    'build',
+    `--runtime=${runtime}`,
+    `--runtime-version=${runtimeVersion}`,
+    '--CDSUBMODULE_CHECK=OFF',
+    '--CDLOCAL_MIRROR=https://oxen.rocks/deps',
+    '--CDENABLE_NETWORKING=OFF',
+    '--CDWITH_TESTS=OFF',
+  ],
+  { stdio: 'inherit', shell: true },
+)
+
+process.exit(result.status == null ? 1 : result.status)


### PR DESCRIPTION
## Summary

The `install` script hardcoded `--runtime=electron --runtime-version=40.0.0`. Reading those two values from env vars (with the same defaults) lets a non-Electron consumer opt in via:

```
LIBSESSION_RUNTIME=node LIBSESSION_RUNTIME_VERSION=22.22.2 npm install
```

Defaults are preserved, so existing `npm install` invocations build identically.

## Test plan

- [ ] `pnpm install` with no env vars → builds for Electron 40 (unchanged)
- [ ] `LIBSESSION_RUNTIME=node LIBSESSION_RUNTIME_VERSION=22.22.2 pnpm install` → builds for Node 22