### PR TITLE
fix(addon): unref TSFN, env cleanup hook + sys.path strip

### DIFF
--- a/build_release_archive.py
+++ b/build_release_archive.py
@@ -1,6 +1,23 @@
 #!/usr/bin/python3
 # -*- coding: utf-8 -*-
+"""Thin wrapper around the pip-pinned `git-archive-all` console entry.
+
+Originally `from git_archive_all import main` after a bare `import sys`,
+which imports `git_archive_all` with `sys.path[0]` set to this script's
+directory (the repo root). A checked-in `git_archive_all.py` or
+`git_archive_all/` directory in the repo would then shadow the
+hash-pinned wheel and execute arbitrary code at release-tarball time.
+Strip `sys.path[0]` before the import so the venv (or site-packages)
+is the only source of truth.
+"""
 import sys
+import os
+
+# Drop sys.path[0] (this script's directory) so an attacker can't
+# shadow the pinned package by adding a same-named module to the repo.
+if sys.path and sys.path[0] in ("", os.path.dirname(os.path.abspath(__file__))):
+    del sys.path[0]
+
 from git_archive_all import main
 
 sys.exit(main())

--- a/src/addon.cpp
+++ b/src/addon.cpp
@@ -22,8 +22,29 @@ Napi::Object InitAll(Napi::Env env, Napi::Object exports) {
             "LoggerCallback",
             0,
             1);
+    // The logger callback is fire-and-forget. Without Unref(), the
+    // TSFN keeps a strong ref on the loop and a `require()` from a
+    // short-lived CLI hangs forever waiting on the TSFN.
+    tsfn.Unref(env);
+
+    // Release the TSFN when the N-API env tears down. Without this,
+    // a later libsession log from a background thread could
+    // BlockingCall into a destroyed env (abort / UAF).
+    napi_add_env_cleanup_hook(
+            env,
+            [](void*) {
+                if (tsfn) {
+                    tsfn.Release();
+                    tsfn = nullptr;
+                }
+            },
+            nullptr);
 
     session::add_logger([](std::string_view msg) {
+        // env-cleanup may have raced ahead — silently drop the log
+        // instead of aborting on a released TSFN.
+        if (!tsfn)
+            return;
         tsfn.BlockingCall(
                 new std::string(msg),
                 [](Napi::Env env, Napi::Function jsCallback, std::string* msg) {


### PR DESCRIPTION
Two unrelated fixes bundled (small surface):

1. `src/addon.cpp`: `tsfn.Unref(env)` + `napi_add_env_cleanup_hook` so a CLI-style `require()` doesn't hang on the TSFN's strong ref, and a later libsession log from a background thread doesn't BlockingCall into a destroyed env (abort / UAF). The logger callback already drops messages when the TSFN has been released.

2. `build_release_archive.py`: strip `sys.path[0]` (the script's own directory) before `import git_archive_all`, so a checked-in `git_archive_all.py` (or directory) at the repo root can't shadow the hash-pinned wheel and execute arbitrary code at release-tarball time.

## Test plan
- [ ] `pnpm install` from a freshly-cloned repo works
- [ ] A short-lived CLI that `require()`s this binding exits cleanly (no hang)
- [ ] `prepare_release.sh` builds the tarball as before